### PR TITLE
[#42]  Refactor and centralize error and empty screen

### DIFF
--- a/assets/images/ic_empty_content.svg
+++ b/assets/images/ic_empty_content.svg
@@ -1,0 +1,17 @@
+<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g clip-path="url(#clip0_7149_34)">
+        <path
+            d="M48.4115 23.9411V16.1765C48.4115 14.8036 47.8662 13.4869 46.8954 12.5162C45.9246 11.5454 44.608 11 43.2351 11H12.1764C10.8036 11 9.48692 11.5454 8.51614 12.5162C7.54537 13.4869 7 14.8036 7 16.1765V29.1176C7 30.4904 7.54537 31.8071 8.51614 32.7779C9.48692 33.7486 10.8036 34.294 12.1764 34.294H25.1176"
+            stroke="#C7C7C7" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+        <path
+            d="M39.3536 42.0582C42.9272 42.0582 45.8242 39.1612 45.8242 35.5877C45.8242 32.0141 42.9272 29.1171 39.3536 29.1171C35.78 29.1171 32.8831 32.0141 32.8831 35.5877C32.8831 39.1612 35.78 42.0582 39.3536 42.0582Z"
+            stroke="#C7C7C7" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+        <path d="M44.5303 40.7641L51.0008 47.2347" stroke="#C7C7C7" stroke-width="3" stroke-linecap="round"
+            stroke-linejoin="round" />
+    </g>
+    <defs>
+        <clipPath id="clip0_7149_34">
+            <rect width="56" height="56" fill="white" />
+        </clipPath>
+    </defs>
+</svg>

--- a/assets/images/ic_generic_error.svg
+++ b/assets/images/ic_generic_error.svg
@@ -1,0 +1,9 @@
+<svg width="57" height="56" viewBox="0 0 57 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+        d="M28.5 51.3333C41.3866 51.3333 51.8333 40.8866 51.8333 28C51.8333 15.1134 41.3866 4.66666 28.5 4.66666C15.6134 4.66666 5.16667 15.1134 5.16667 28C5.16667 40.8866 15.6134 51.3333 28.5 51.3333Z"
+        stroke="#C7C7C7" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M19.1667 39.6667C21.2949 36.8331 24.6834 35 28.5 35C32.3166 35 35.7051 36.8331 37.8333 39.6667"
+        stroke="#C7C7C7" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M19.1876 21H19.1667M37.8333 21H37.8123" stroke="#C7C7C7" stroke-width="3" stroke-linecap="round"
+        stroke-linejoin="round" />
+</svg>

--- a/lib/core/repository/survey/survey_repository.dart
+++ b/lib/core/repository/survey/survey_repository.dart
@@ -7,5 +7,6 @@ abstract class SurveyRepository {
     required int pageNumber,
     required int pageSize,
     required bool isForceReload,
+    bool shouldClearCache = false,
   });
 }

--- a/lib/core/repository/survey/survey_repository_impl.dart
+++ b/lib/core/repository/survey/survey_repository_impl.dart
@@ -20,7 +20,12 @@ class SurveyRepositoryImpl extends SurveyRepository {
     required int pageNumber,
     required int pageSize,
     required bool isForceReload,
+    bool shouldClearCache = false,
   }) async {
+    if (shouldClearCache) {
+      await localStorageRepository.clearCachedSurveyModelList();
+    }
+
     if (isForceReload) {
       return _getRemoteSurveyList(pageNumber: pageNumber, pageSize: pageSize);
     }
@@ -56,7 +61,6 @@ class SurveyRepositoryImpl extends SurveyRepository {
                 ?.map((surveyData) => SurveyModel.fromResponse(res: surveyData))
                 .toList() ??
             List.empty();
-        await localStorageRepository.clearCachedSurveyModelList();
         await localStorageRepository.updateCachedSurveyModelList(list);
         return list;
       },

--- a/lib/core/ui/component/nimble_button.dart
+++ b/lib/core/ui/component/nimble_button.dart
@@ -23,6 +23,10 @@ class NimbleButton extends StatelessWidget {
       width: width,
       child: ElevatedButton(
         style: ElevatedButton.styleFrom(
+          foregroundColor: ColorName.blackPrimaryText,
+          backgroundColor: Colors.white,
+          disabledForegroundColor: Colors.black38,
+          disabledBackgroundColor: Colors.grey,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(AppDimension.borderRadius),
           ),
@@ -32,7 +36,6 @@ class NimbleButton extends StatelessWidget {
           buttonText,
           style: TextStyle(
             fontSize: AppTextSize.textSizeMedium,
-            color: ColorName.blackPrimaryText,
             fontWeight: FontWeight.bold,
           ),
         ),

--- a/lib/core/ui/component/nimble_text_field.dart
+++ b/lib/core/ui/component/nimble_text_field.dart
@@ -7,18 +7,21 @@ class NimbleTextField extends StatelessWidget {
   final bool obscureText;
   final Function(String) onChanged;
   final Widget? suffix;
+  final bool enabled;
 
   const NimbleTextField({
     required this.hintText,
     required this.onChanged,
     this.suffix,
     this.obscureText = false,
+    this.enabled = true,
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
     return TextField(
+      enabled: enabled,
       obscureText: obscureText,
       style: TextStyle(color: ColorName.primaryText),
       decoration: InputDecoration(

--- a/lib/core/ui/component/screen/base_nimble_error_screen.dart
+++ b/lib/core/ui/component/screen/base_nimble_error_screen.dart
@@ -25,36 +25,35 @@ class BaseNimbleErrorScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Container(
+        padding: const EdgeInsets.all(AppDimension.spacingMedium),
         color: Colors.black,
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(AppDimension.spacingMedium),
-            child: Column(
-              spacing: AppDimension.spacingMedium,
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                icon ?? SizedBox.shrink(),
-                Text(
-                  title,
-                  style: TextStyle(
-                    color: ColorName.primaryText,
-                    fontSize: AppTextSize.textSizeLarge,
-                  ),
+        child: Align(
+          alignment: Alignment.center,
+          child: Column(
+            spacing: AppDimension.spacingMedium,
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              icon ?? SizedBox.shrink(),
+              Text(
+                title,
+                style: TextStyle(
+                  color: ColorName.primaryText,
+                  fontSize: AppTextSize.textSizeLarge,
                 ),
-                Text(
-                  description,
-                  style: TextStyle(
-                    color: ColorName.secondaryText,
-                    fontSize: AppTextSize.textSizeMedium,
-                  ),
+              ),
+              Text(
+                description,
+                style: TextStyle(
+                  color: ColorName.secondaryText,
+                  fontSize: AppTextSize.textSizeMedium,
                 ),
-                NimbleButton(
-                  buttonText: primaryButtonLabel,
-                  onPressed: onPressed,
-                ),
-              ],
-            ),
+              ),
+              NimbleButton(
+                buttonText: primaryButtonLabel,
+                onPressed: onPressed,
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/core/ui/component/screen/base_nimble_error_screen.dart
+++ b/lib/core/ui/component/screen/base_nimble_error_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:nimble_survey_app/core/ui/theme/app_dimension.dart';
+
+import '../../../../gen/colors.gen.dart';
+import '../../theme/app_text_size.dart';
+import '../nimble_button.dart';
+
+class BaseNimbleErrorScreen extends StatelessWidget {
+  final Widget? icon;
+  final String title;
+  final String description;
+  final String primaryButtonLabel;
+  final VoidCallback? onPressed;
+
+  const BaseNimbleErrorScreen({
+    this.icon,
+    this.title = "",
+    this.description = "",
+    this.primaryButtonLabel = "",
+    this.onPressed,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        color: Colors.black,
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(AppDimension.spacingMedium),
+            child: Column(
+              spacing: AppDimension.spacingMedium,
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                icon ?? SizedBox.shrink(),
+                Text(
+                  title,
+                  style: TextStyle(
+                    color: ColorName.primaryText,
+                    fontSize: AppTextSize.textSizeLarge,
+                  ),
+                ),
+                Text(
+                  description,
+                  style: TextStyle(
+                    color: ColorName.secondaryText,
+                    fontSize: AppTextSize.textSizeMedium,
+                  ),
+                ),
+                NimbleButton(
+                  buttonText: primaryButtonLabel,
+                  onPressed: onPressed,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/login/loginform/login_form.dart
+++ b/lib/features/auth/login/loginform/login_form.dart
@@ -39,6 +39,7 @@ class LoginForm extends ConsumerWidget {
     Widget createEmailTextField() {
       return NimbleTextField(
         key: AppWidgetKey.loginEmailTextField,
+        enabled: !authUiModel.isLoading,
         hintText: AppLocalizations.of(context)?.email ?? "",
         onChanged:
             (value) =>
@@ -49,34 +50,23 @@ class LoginForm extends ConsumerWidget {
     Widget createPasswordTextField() {
       return NimbleTextField(
         key: AppWidgetKey.loginPasswordTextField,
-        suffix:
-            authUiModel.isLoading
-                ? Padding(
-                  padding: const EdgeInsets.all(AppDimension.spacingExtraSmall),
-                  child: Center(
-                    child: Align(
-                      alignment: Alignment.centerRight,
-                      child: SizedBox(
-                        width: AppDimension.spacingMedium,
-                        height: AppDimension.spacingMedium,
-                        child: CircularProgressIndicator(),
-                      ),
-                    ),
-                  ),
-                )
-                : TextButton(
-                  key: AppWidgetKey.loginResetPasswordButton,
-                  onPressed: () {
+        enabled: !authUiModel.isLoading,
+        suffix: TextButton(
+          key: AppWidgetKey.loginResetPasswordButton,
+          onPressed:
+              !authUiModel.isLoading
+                  ? () {
                     context.go('/auth/reset');
-                  },
-                  child: Text(
-                    AppLocalizations.of(context)?.loginForgotPassword ?? "",
-                    style: TextStyle(
-                      fontSize: AppTextSize.textSizeSmall,
-                      color: ColorName.secondaryText,
-                    ),
-                  ),
-                ),
+                  }
+                  : null,
+          child: Text(
+            AppLocalizations.of(context)?.loginForgotPassword ?? "",
+            style: TextStyle(
+              fontSize: AppTextSize.textSizeSmall,
+              color: ColorName.secondaryText,
+            ),
+          ),
+        ),
         hintText: AppLocalizations.of(context)?.loginPassword ?? "",
         obscureText: true,
         onChanged:

--- a/lib/features/auth/login/loginform/login_form.dart
+++ b/lib/features/auth/login/loginform/login_form.dart
@@ -5,9 +5,9 @@ import 'package:go_router/go_router.dart';
 import 'package:nimble_survey_app/core/constants/app_widget_key.dart';
 import 'package:nimble_survey_app/core/ui/component/nimble_login_button.dart';
 import 'package:nimble_survey_app/core/ui/component/nimble_text_field.dart';
-import 'package:nimble_survey_app/features/auth/login/model/auth_ui_model.dart';
 import 'package:nimble_survey_app/l10n/app_localizations.dart';
 
+import '../../../../core/ui/component/nimble_button.dart';
 import '../../../../core/ui/theme/app_dimension.dart';
 import '../../../../core/ui/theme/app_text_size.dart';
 import '../../../../gen/assets.gen.dart';
@@ -92,13 +92,18 @@ class LoginForm extends ConsumerWidget {
           : NimbleButton(
             key: AppWidgetKey.loginSubmitButton,
             buttonText: AppLocalizations.of(context)?.login ?? "",
-            onPressed: () async {
-              FocusManager.instance.primaryFocus?.unfocus();
-              if (loginFormUiModel.isLoginEnabled == false) return;
-              await ref
-                  .read(authViewModelProvider.notifier)
-                  .login(loginFormUiModel.email, loginFormUiModel.password);
-            },
+            onPressed:
+                loginFormUiModel.isLoginEnabled == true
+                    ? () async {
+                      FocusManager.instance.primaryFocus?.unfocus();
+                      await ref
+                          .read(authViewModelProvider.notifier)
+                          .login(
+                            loginFormUiModel.email,
+                            loginFormUiModel.password,
+                          );
+                    }
+                    : null,
           );
     }
 

--- a/lib/features/auth/login/loginform/login_form.dart
+++ b/lib/features/auth/login/loginform/login_form.dart
@@ -3,8 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nimble_survey_app/core/constants/app_widget_key.dart';
-import 'package:nimble_survey_app/core/ui/component/nimble_login_button.dart';
 import 'package:nimble_survey_app/core/ui/component/nimble_text_field.dart';
+import 'package:nimble_survey_app/features/auth/login/model/auth_ui_model.dart';
 import 'package:nimble_survey_app/l10n/app_localizations.dart';
 
 import '../../../../core/ui/component/nimble_button.dart';

--- a/lib/features/auth/resetpassword/reset_password_screen.dart
+++ b/lib/features/auth/resetpassword/reset_password_screen.dart
@@ -100,7 +100,10 @@ class ResetPasswordScreen extends ConsumerWidget {
                 key: AppWidgetKey.resetPasswordSubmitButton,
                 buttonText:
                     AppLocalizations.of(context)?.resetPasswordReset ?? "",
-                onPressed: resetPasswordUiModel.isResetEnabled == true ? onResetPasswordSubmit : null,
+                onPressed:
+                    resetPasswordUiModel.isResetEnabled == true
+                        ? onResetPasswordSubmit
+                        : null,
               ),
         ],
       ),

--- a/lib/features/auth/resetpassword/reset_password_screen.dart
+++ b/lib/features/auth/resetpassword/reset_password_screen.dart
@@ -8,7 +8,7 @@ import 'package:nimble_survey_app/core/constants/app_widget_key.dart';
 import 'package:nimble_survey_app/features/auth/resetpassword/model/reset_password_ui_model.dart';
 import 'package:nimble_survey_app/features/auth/resetpassword/viewmodel/reset_password_view_model.dart';
 
-import '../../../core/ui/component/nimble_login_button.dart';
+import '../../../core/ui/component/nimble_button.dart';
 import '../../../core/ui/component/nimble_text_field.dart';
 import '../../../core/ui/theme/app_dimension.dart';
 import '../../../core/ui/theme/app_text_size.dart';
@@ -24,8 +24,6 @@ class ResetPasswordScreen extends ConsumerWidget {
     final screenHeight = MediaQuery.of(context).size.height;
 
     void onResetPasswordSubmit() async {
-      if (!resetPasswordUiModel.isResetEnabled) return;
-
       final title = AppLocalizations.of(context)?.resetPasswordSuccessTitle;
       final description =
           AppLocalizations.of(context)?.resetPasswordSuccessDescription;
@@ -102,7 +100,7 @@ class ResetPasswordScreen extends ConsumerWidget {
                 key: AppWidgetKey.resetPasswordSubmitButton,
                 buttonText:
                     AppLocalizations.of(context)?.resetPasswordReset ?? "",
-                onPressed: onResetPasswordSubmit,
+                onPressed: resetPasswordUiModel.isResetEnabled == true ? onResetPasswordSubmit : null,
               ),
         ],
       ),

--- a/lib/features/auth/resetpassword/reset_password_screen.dart
+++ b/lib/features/auth/resetpassword/reset_password_screen.dart
@@ -89,6 +89,7 @@ class ResetPasswordScreen extends ConsumerWidget {
           ),
           NimbleTextField(
             key: AppWidgetKey.resetPasswordEmailTextField,
+            enabled: !resetPasswordUiModel.isLoading,
             hintText: AppLocalizations.of(context)?.email ?? "",
             onChanged: (value) {
               ref.read(resetPasswordViewModelProvider.notifier).setEmail(value);

--- a/lib/features/home/ui/component/surveylist/survey_list.dart
+++ b/lib/features/home/ui/component/surveylist/survey_list.dart
@@ -186,7 +186,9 @@ class SurveyListState extends ConsumerState<SurveyList> {
         isRefreshSuccess,
       ) {
         if (isRefreshSuccess == true) {
-          _controller.jumpToPage(currentIndex);
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            _controller.jumpToPage(currentIndex);
+          });
         } else if (isRefreshSuccess == false) {
           if (mounted) {
             Fluttertoast.showToast(
@@ -207,7 +209,7 @@ class SurveyListState extends ConsumerState<SurveyList> {
       isFirstLoad,
       isRefreshSuccess,
     ) {
-      if (isLoading) {
+      if (isLoading && isFirstLoad) {
         return const ColoredBox(
           color: Colors.black,
           child: Center(child: CircularProgressIndicator()),

--- a/lib/features/home/ui/component/surveylist/survey_list.dart
+++ b/lib/features/home/ui/component/surveylist/survey_list.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:nimble_survey_app/core/model/survey_model.dart';
+import 'package:nimble_survey_app/core/ui/component/screen/base_nimble_error_screen.dart';
 import 'package:nimble_survey_app/core/ui/theme/app_dimension.dart';
 import 'package:nimble_survey_app/features/home/model/survey_list_ui_model.dart';
 import 'package:nimble_survey_app/features/home/ui/component/surveylist/survey_background_image.dart';
@@ -11,6 +12,7 @@ import 'package:nimble_survey_app/l10n/app_localizations.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 
 import '../loading/bottom_loading_content.dart';
+import '../../../../../l10n/app_localizations.dart';
 
 class SurveyList extends ConsumerStatefulWidget {
   const SurveyList({super.key});
@@ -140,17 +142,16 @@ class SurveyListState extends ConsumerState<SurveyList> {
   }
 
   Widget _createEmptyListContent() {
-    return Container(
-      color: Colors.black,
-      child: Center(
-        child: Text(
-          AppLocalizations.of(context)?.homeEmptySurveyList ?? '',
-          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-            color: Theme.of(context).colorScheme.onSurface,
-          ),
-          textAlign: TextAlign.center,
-        ),
-      ),
+    return BaseNimbleErrorScreen(
+      icon: Assets.images.icEmptyContent.svg(),
+      title: AppLocalizations.of(context)?.surveyListEmptyContentTitle ?? '',
+      description:
+      AppLocalizations.of(context)?.surveyListEmptyContentDescription ??
+          '',
+      primaryButtonLabel: AppLocalizations.of(context)?.genericTryAgain ?? '',
+      onPressed: () async {
+        // TODO handle refresh
+      },
     );
   }
 
@@ -181,6 +182,13 @@ class SurveyListState extends ConsumerState<SurveyList> {
     final isLoading = ref.watch(surveyListViewModelProvider).isLoading;
     final isFirstLoad = ref.watch(surveyListViewModelProvider).isFirstLoad;
     final currentIndex = ref.watch(surveyListViewModelProvider).currentIndex;
+
+    if (isLoading) {
+      return Container(
+        color: Colors.black,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
 
     if (surveyList.isEmpty) {
       if (isFirstLoad) {

--- a/lib/features/home/ui/component/surveylist/survey_list.dart
+++ b/lib/features/home/ui/component/surveylist/survey_list.dart
@@ -11,8 +11,8 @@ import 'package:nimble_survey_app/features/home/ui/viewmodel/survey_list_view_mo
 import 'package:nimble_survey_app/l10n/app_localizations.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 
+import '../../../../../gen/assets.gen.dart';
 import '../loading/bottom_loading_content.dart';
-import '../../../../../l10n/app_localizations.dart';
 
 class SurveyList extends ConsumerStatefulWidget {
   const SurveyList({super.key});
@@ -146,8 +146,7 @@ class SurveyListState extends ConsumerState<SurveyList> {
       icon: Assets.images.icEmptyContent.svg(),
       title: AppLocalizations.of(context)?.surveyListEmptyContentTitle ?? '',
       description:
-      AppLocalizations.of(context)?.surveyListEmptyContentDescription ??
-          '',
+          AppLocalizations.of(context)?.surveyListEmptyContentDescription ?? '',
       primaryButtonLabel: AppLocalizations.of(context)?.genericTryAgain ?? '',
       onPressed: () async {
         // TODO handle refresh

--- a/lib/features/home/ui/component/surveylist/survey_list.dart
+++ b/lib/features/home/ui/component/surveylist/survey_list.dart
@@ -149,7 +149,7 @@ class SurveyListState extends ConsumerState<SurveyList> {
           AppLocalizations.of(context)?.surveyListEmptyContentDescription ?? '',
       primaryButtonLabel: AppLocalizations.of(context)?.genericTryAgain ?? '',
       onPressed: () async {
-        // TODO handle refresh
+        await ref.read(surveyListViewModelProvider.notifier).refresh();
       },
     );
   }

--- a/lib/features/home/ui/viewmodel/survey_list_view_model.dart
+++ b/lib/features/home/ui/viewmodel/survey_list_view_model.dart
@@ -53,6 +53,7 @@ class SurveyListViewModel extends _$SurveyListViewModel {
     final List<SurveyModel> surveyList = await _getSurveyList(
       pageNumber: 1,
       isForceReload: true,
+      shouldClearCache: true,
     );
     if (surveyList.isNotEmpty) {
       _currentPage = 2; // Next page
@@ -95,11 +96,13 @@ class SurveyListViewModel extends _$SurveyListViewModel {
   Future<List<SurveyModel>> _getSurveyList({
     required int pageNumber,
     bool isForceReload = false,
+    bool shouldClearCache = false,
   }) async {
     final result = await _surveyRepository.getSurveyList(
       pageNumber: pageNumber,
       pageSize: AppConstants.defaultPageSize,
       isForceReload: isForceReload,
+      shouldClearCache: shouldClearCache,
     );
     return result is Success ? (result as Success).data : List.empty();
   }

--- a/lib/features/surveydetails/ui/question_list_screen.dart
+++ b/lib/features/surveydetails/ui/question_list_screen.dart
@@ -9,7 +9,7 @@ import 'package:nimble_survey_app/core/model/survey_question_model.dart';
 import 'package:nimble_survey_app/features/surveydetails/model/survey_details_ui_model.dart';
 
 import '../../../core/constants/app_constants.dart';
-import '../../../core/ui/component/nimble_login_button.dart';
+import '../../../core/ui/component/nimble_button.dart';
 import '../../../core/ui/theme/app_dimension.dart';
 import '../../../core/ui/theme/app_text_size.dart';
 import '../../../gen/assets.gen.dart';

--- a/lib/features/surveydetails/ui/survey_details_screen.dart
+++ b/lib/features/surveydetails/ui/survey_details_screen.dart
@@ -7,6 +7,7 @@ import 'package:nimble_survey_app/core/constants/app_widget_key.dart';
 
 import '../../../core/model/survey_details_model.dart';
 import '../../../core/ui/component/nimble_button.dart';
+import '../../../core/ui/component/screen/base_nimble_error_screen.dart';
 import '../../../core/ui/theme/app_dimension.dart';
 import '../../../core/ui/theme/app_text_size.dart';
 import '../../../gen/assets.gen.dart';
@@ -78,33 +79,29 @@ class SurveyDetailsScreenState extends ConsumerState<SurveyDetailsScreen> {
     final SurveyDetailsUiModel uiModel = ref.watch(
       surveyDetailsViewModelProvider,
     );
+    final isLoading = uiModel.isLoading;
     final SurveyDetailsModel? survey = uiModel.surveyDetails;
 
-    if (survey == null) {
-      // TODO replace with error screen
-      return Stack(
-        children: [
-          SurveyBackgroundImage(imageUrl: ''),
-          uiModel.isLoading
-              ? Positioned.fill(
-                child: Center(child: CircularProgressIndicator()),
-              )
-              : Positioned.fill(
-                child: Center(
-                  child: CircleAvatar(
-                    backgroundColor: Colors.transparent,
-                    radius: AppDimension.profileMediumIconDiameter / 2,
-                    child: Icon(
-                      Icons.no_backpack,
-                      color: Colors.white,
-                      size: AppDimension.profileMediumIconDiameter,
-                    ),
-                  ),
-                ),
-              ),
-        ],
+    if (isLoading) {
+      return Container(
+        color: Colors.black,
+        child: Center(child: CircularProgressIndicator()),
       );
     }
+
+    if (survey == null) {
+      return BaseNimbleErrorScreen(
+        icon: Assets.images.icGenericError.svg(),
+        title: AppLocalizations.of(context)?.genericErrorTitle ?? '',
+        description:
+            AppLocalizations.of(context)?.genericErrorDescription ?? '',
+        primaryButtonLabel: AppLocalizations.of(context)?.genericTryAgain ?? '',
+        onPressed: () async {
+          // TODO handle refresh
+        },
+      );
+    }
+
     return Scaffold(
       key: AppWidgetKey.surveyDetailsScreen,
       body: Stack(

--- a/lib/features/surveydetails/ui/survey_details_screen.dart
+++ b/lib/features/surveydetails/ui/survey_details_screen.dart
@@ -6,7 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:nimble_survey_app/core/constants/app_widget_key.dart';
 
 import '../../../core/model/survey_details_model.dart';
-import '../../../core/ui/component/nimble_login_button.dart';
+import '../../../core/ui/component/nimble_button.dart';
 import '../../../core/ui/theme/app_dimension.dart';
 import '../../../core/ui/theme/app_text_size.dart';
 import '../../../gen/assets.gen.dart';

--- a/lib/features/surveydetails/ui/survey_details_screen.dart
+++ b/lib/features/surveydetails/ui/survey_details_screen.dart
@@ -97,7 +97,9 @@ class SurveyDetailsScreenState extends ConsumerState<SurveyDetailsScreen> {
             AppLocalizations.of(context)?.genericErrorDescription ?? '',
         primaryButtonLabel: AppLocalizations.of(context)?.genericTryAgain ?? '',
         onPressed: () async {
-          // TODO handle refresh
+          await ref
+              .read(surveyDetailsViewModelProvider.notifier)
+              .initialLoad(id: widget.id);
         },
       );
     }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -25,5 +25,10 @@
   "numberRatingBarAnswerNegativeText": "Not at all Likely",
   "textAreaAnswerHint": "Your thoughts",
   "surveyCompletionDefaultText": "Thanks for taking the survey.",
-  "surveyFailedToSubmit": "Survey submission Failed, please try again"
+  "surveyFailedToSubmit": "Survey submission Failed, please try again",
+  "genericErrorTitle": "Something went wrong",
+  "genericErrorDescription": "Please refresh the page",
+  "genericTryAgain": "Try Again",
+  "surveyListEmptyContentTitle": "There are no survey available",
+  "surveyListEmptyContentDescription": "Please try refreshing the page to get latest surveys"
 }

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -25,5 +25,10 @@
     "numberRatingBarAnswerNegativeText": "ไม่น่าจะเป็นไปได้",
     "textAreaAnswerHint": "ความคิดเห็นของคุณ",
     "surveyCompletionDefaultText": "ขอบคุณที่สละเวลาตอบแบบสอบถาม",
-    "surveyFailedToSubmit": "การส่งแบบสำรวจล้มเหลว กรุณาลองอีกครั้ง"
+  "surveyFailedToSubmit": "การส่งแบบสำรวจล้มเหลว กรุณาลองอีกครั้ง",
+  "genericErrorTitle": "เกิดข้อผิดพลาดบางอย่าง",
+  "genericErrorDescription": "กรุณารีเฟรชหน้า",
+  "genericTryAgain": "ลองอีกครั้ง",
+  "surveyListEmptyContentTitle": "ยังไม่มีแบบสำรวจ",
+  "surveyListEmptyContentDescription": "กรุณารีเฟรชหน้าเพื่อรับแบบสำรวจล่าสุด"
 }

--- a/test/features/home/ui/viewmodel/survey_list_view_model_test.dart
+++ b/test/features/home/ui/viewmodel/survey_list_view_model_test.dart
@@ -131,6 +131,7 @@ void main() {
           pageNumber: any(named: 'pageNumber'),
           pageSize: AppConstants.defaultPageSize,
           isForceReload: any(named: 'isForceReload'),
+          shouldClearCache: any(named: 'shouldClearCache'),
         ),
       ).thenAnswer((_) async => Success([MockUtil.mockSurveyModel]));
 


### PR DESCRIPTION
#42

## What happened 👀
- Refactor error and empty content screens to use common UI component
- Prevent pressing button for some screens on api loading
- Refactor some unhappy flow to be less disruptive i.e. on loading survey screen, show black screen with indicators instead of empty screens when loading
- Add string resource for error screens
- refactor loading flow on login form

## Insight 📝

N/A

## Proof Of Work 📹
- Unit tests passed ✅ 
- UI tests passed ✅ 
<img width="428" height="433" alt="Screenshot 2568-09-19 at 11 43 09" src="https://github.com/user-attachments/assets/b080d080-e20d-4c49-9abe-90bf372cc139" />

### Loading state refactoring

https://github.com/user-attachments/assets/1a31b95a-de74-46ca-8290-e363e52117a4

### Generic error screen

https://github.com/user-attachments/assets/57d8482b-368e-47b7-8834-d908e3c8a607

